### PR TITLE
Exclude LUsineDigitale

### DIFF
--- a/data.py
+++ b/data.py
@@ -22,4 +22,5 @@ IGNORED = ( "liberezledoigt",
             "DigiToSell",
             "AurelieMorinea",
             "lyonelkaufmann",
+            "LUsineDigitale"
         )


### PR DESCRIPTION
Ou alors il faudrait filtrer l’emission du message uniquement sur le contenu du tweet, pas sur l’handle utilisateur pour éviter que tous les comptes avec « digital » soient spammés.